### PR TITLE
Fix providing serial number for MDM solutions

### DIFF
--- a/initrd/init
+++ b/initrd/init
@@ -118,6 +118,7 @@ device_information()
 	echo ro.product.bliss.model="$BOARD" >> /tmp/device.prop
 	echo ro.product.board="$BOARD" >> /tmp/device.prop
 	echo ro.bliss.serialnumber="$SERIALNO" >> /tmp/device.prop
+	echo ro.serialno="$SERIALNO" >> /tmp/device.prop
 	mount --bind /tmp/device.prop system/vendor/etc/device.prop
 }
 


### PR DESCRIPTION
MDM solution could read serial number by standard android API. It fix it.